### PR TITLE
Avoid rising an error when default mapping exists

### DIFF
--- a/plugin/difforig.vim
+++ b/plugin/difforig.vim
@@ -31,7 +31,7 @@ if !(exists(':DiffOrig') == 2)
     command -bar -nargs=0 DiffOrig call difforig#main()
 endif
 
-if !hasmapto('<Plug>(DiffOrig)')
+if !hasmapto('<Plug>(DiffOrig)') && mapcheck('<Leader>o', 'n') is# ''
     nmap <silent> <unique> <Leader>o <Plug>(DiffOrig)
 endif
 nnoremap <unique> <Plug>(DiffOrig) :<C-U>call difforig#main()<CR>


### PR DESCRIPTION
If `<Leader>o` is already mapped, an error is echoed. By checking if it is being used before creating a new mapping, we avoid annoying the user